### PR TITLE
Upgrade from Tex Live 2023 to 2024 (short-term solution)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     container: tunathu/thuthesis-test-env
     steps:
       # fix container
-      - run: apt update && apt install git -y
+      - run: apt update && apt install git wget -y
       - uses: actions/checkout@v2
       - name: Install required packages
         run: bash .github/workflows/install-packages.sh

--- a/.github/workflows/install-packages.sh
+++ b/.github/workflows/install-packages.sh
@@ -20,6 +20,10 @@ MARKDOWN_PKGS="markdown fancyvrb csvsimple gobble"
 DOC_PKGS="hologo listings xcolor $MARKDOWN_PKGS"
 EXAMPLE_PKGS="float fp metalogo multirow mwe"
 
+wget https://mirror.ctan.org/systems/texlive/tlnet/update-tlmgr-latest.sh
+sh update-tlmgr-latest.sh -- --upgrade
+tlmgr update --self --all
+luaotfload-tool -fu
 tlmgr install $BIN_PKGS $REQUIRED_PKGS $FONT_PKGS $EXTRA_PKGS $DOC_PKGS \
   $EXAMPLE_PKGS
 tlmgr install pgfplots


### PR DESCRIPTION
### Description

Fixed installation errors caused by version issues.
 
```bash
tlmgr: Local TeX Live (2023) is older than remote repository (2024).
Cross release updates are only supported with
  update-tlmgr-latest(.sh/.exe) --update
See https://tug.org/texlive/upgrade.html for details.
Error: Process completed with exit code 1.
```
